### PR TITLE
fix dark theme blockquote text color

### DIFF
--- a/assets/tailwind.css
+++ b/assets/tailwind.css
@@ -448,6 +448,10 @@
   color: var(--tw-prose-body);
   max-width: inherit;
 }
+.topic-body .cooked :where(p):not(:where([class~="not-prose"] *)){
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
 .topic-body .cooked :where([class~="lead"]):not(:where([class~="not-prose"] *)){
   color: var(--tw-prose-lead);
   font-size: 1.25em;
@@ -743,10 +747,6 @@
   --tw-prose-invert-td-borders: #374151;
   font-size: 1rem;
   line-height: 1.75;
-}
-.topic-body .cooked :where(p):not(:where([class~="not-prose"] *)){
-  margin-top: 1.25em;
-  margin-bottom: 1.25em;
 }
 .topic-body .cooked :where(video):not(:where([class~="not-prose"] *)){
   margin-top: 2em;

--- a/assets/tailwind.css
+++ b/assets/tailwind.css
@@ -864,7 +864,7 @@
     color: #FFF;
   }
   .topic-body .cooked :where(blockquote):not(:where([class~="not-prose"] *)){
-    color: #30333a;
+    color: #FFF;
   }
   .topic-body .cooked :where(code):not(:where([class~="not-prose"] *)){
     color: #FFDE63;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -138,7 +138,7 @@ module.exports = {
               color: "#FFF",
             },
             blockquote: {
-              color: neo4jColors.gray.dark
+              color: "#FFF"
             },
             code: {
               color: neo4jColors.yellow.neo4j,


### PR DESCRIPTION
I tested this change by visiting: https://community.neo4j.com/t/set-undirected-relationship/61207 where the text color was wrong in dark mode.

Using chrome developer tools, I changed the css to match this PR, and toggled between light/dark mode in emulation settings to verify the text color for the code blockquotes now looks good in both themes.
